### PR TITLE
Updating deprecated tags

### DIFF
--- a/lib/src/main/java/com/segment/analytics/kotlin/destinations/firebase/FirebaseDestination.kt
+++ b/lib/src/main/java/com/segment/analytics/kotlin/destinations/firebase/FirebaseDestination.kt
@@ -198,7 +198,7 @@ class FirebaseDestination(
             "revenue" to FirebaseAnalytics.Param.VALUE,
             "order_id" to FirebaseAnalytics.Param.TRANSACTION_ID,
             "currency" to FirebaseAnalytics.Param.CURRENCY,
-            "products" to FirebaseAnalytics.Param.ITEM_LIST
+            "products" to FirebaseAnalytics.Param.ITEMS
         )
 
         private val PRODUCT_MAPPER: Map<String, String> = mapOf(
@@ -213,12 +213,12 @@ class FirebaseDestination(
         private val EVENT_MAPPER: Map<String, String> = mapOf(
             "Product Added" to FirebaseAnalytics.Event.ADD_TO_CART,
             "Checkout Started" to FirebaseAnalytics.Event.BEGIN_CHECKOUT,
-            "Order Completed" to FirebaseAnalytics.Event.ECOMMERCE_PURCHASE,
-            "Order Refunded" to FirebaseAnalytics.Event.PURCHASE_REFUND,
+            "Order Completed" to FirebaseAnalytics.Event.PURCHASE,
+            "Order Refunded" to FirebaseAnalytics.Event.REFUND,
             "Product Viewed" to FirebaseAnalytics.Event.VIEW_ITEM,
             "Product List Viewed" to FirebaseAnalytics.Event.VIEW_ITEM_LIST,
             "Payment Info Entered" to FirebaseAnalytics.Event.ADD_PAYMENT_INFO,
-            "Promotion Viewed" to FirebaseAnalytics.Event.PRESENT_OFFER,
+            "Promotion Viewed" to FirebaseAnalytics.Event.VIEW_PROMOTION,
             "Product Added to Wishlist" to FirebaseAnalytics.Event.ADD_TO_WISHLIST,
             "Product Shared" to FirebaseAnalytics.Event.SHARE,
             "Product Clicked" to FirebaseAnalytics.Event.SELECT_CONTENT,
@@ -242,7 +242,7 @@ class FirebaseDestination(
                 finalProperty = PROPERTY_MAPPER[property].toString()
             }
 
-            if (finalProperty == FirebaseAnalytics.Param.ITEM_LIST) {
+            if (finalProperty == FirebaseAnalytics.Param.ITEMS) {
                 val products = properties.getMapList("products") ?: continue
                 val formattedProducts = formatProducts(products)
                 bundle.putParcelableArrayList(finalProperty, formattedProducts)
@@ -267,7 +267,9 @@ class FirebaseDestination(
             for (key in product.keys) {
                 val value = product[key]
                 val finalKey = PRODUCT_MAPPER[key] ?: makeKey(key)
-                mappedProduct.putValue(finalKey, value)
+                if(value != null) {
+                    mappedProduct.putValue(finalKey, value)
+                }
             }
             mappedProducts.add(mappedProduct)
         }

--- a/lib/src/test/java/com/segment/analytics/kotlin/destinations/firebase/FirebaseDestinationTest.kt
+++ b/lib/src/test/java/com/segment/analytics/kotlin/destinations/firebase/FirebaseDestinationTest.kt
@@ -291,7 +291,7 @@ class FirebaseDestinationTests {
             assertEquals("house items", getString("search_term"))
             assertEquals("USD", getString("currency"))
             assertEquals(160, getInt("value"))
-            val products = getParcelableArrayList<Bundle>("item_list")
+            val products = getParcelableArrayList<Bundle>("items")
             with(products!!) {
                 assertEquals(2, size)
                 with(get(0)!!) {


### PR DESCRIPTION
This issue was originally reported as a feature that wasn't ported over from android, but I think that's only true for the Swift version - the same code exists in Kotlin, but some of the tags being used were deprecated.  Please double check that these changes are appropriate.