### PR TITLE
Map Product Clicked to select_item

### DIFF
--- a/lib/src/main/java/com/segment/analytics/kotlin/destinations/firebase/FirebaseDestination.kt
+++ b/lib/src/main/java/com/segment/analytics/kotlin/destinations/firebase/FirebaseDestination.kt
@@ -221,7 +221,7 @@ class FirebaseDestination(
             "Promotion Viewed" to FirebaseAnalytics.Event.VIEW_PROMOTION,
             "Product Added to Wishlist" to FirebaseAnalytics.Event.ADD_TO_WISHLIST,
             "Product Shared" to FirebaseAnalytics.Event.SHARE,
-            "Product Clicked" to FirebaseAnalytics.Event.SELECT_CONTENT,
+            "Product Clicked" to FirebaseAnalytics.Event.SELECT_ITEM,
             "Products Searched" to FirebaseAnalytics.Event.SEARCH
         )
     }


### PR DESCRIPTION
I'm proposing that `Product Clicked` should be mapped to the event `select_item` instead of `select_content` for the reasons described in this PR:
https://github.com/segment-integrations/analytics-swift-firebase/pull/23